### PR TITLE
fix: correct import.meta.env access in Vite

### DIFF
--- a/src/api/commercetools-api.ts
+++ b/src/api/commercetools-api.ts
@@ -6,7 +6,7 @@ import {
 
 import { createApiBuilderFromCtpClient } from '@commercetools/platform-sdk';
 
-const { env } = import.meta;
+const env = import.meta.env;
 
 const projectKey = env.VAR_COMMERCE_TOOLS_PROJECT_KEY;
 const region = env.VAR_COMMERCE_TOOLS_REGION;


### PR DESCRIPTION
Fix env: With destructuring all fields of .env were undefended, had to write directly to env.