### PR TITLE
Refactor/make shared validation

### DIFF
--- a/src/pages/Login/components/LoginForm/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm/LoginForm.tsx
@@ -1,4 +1,3 @@
-import { isEmail, useForm } from '@mantine/form';
 import {
   TextInput,
   PasswordInput,
@@ -7,52 +6,20 @@ import {
   Card,
   Anchor,
   Text,
+  Box,
 } from '@mantine/core';
+import { useForm } from '@mantine/form';
 import { IconAt, IconLock } from '@tabler/icons-react';
-import classes from './LoginForm.module.scss';
 import { Link } from 'react-router';
+import { validateEmail, validatePassword } from '@/utils/mantine-validation';
+import classes from './LoginForm.module.scss';
 
 export const LoginForm = () => {
   const form = useForm({
     initialValues: { email: '', password: '' },
     validate: {
-      email: (value) => {
-        const trimmed = value.trim();
-        if (trimmed !== value)
-          return 'Уберите пробелы в начале или конце email';
-        if (!value.includes('@')) return 'Email должен содержать @';
-        if (value.split('@').length !== 2)
-          return 'Должен быть ровно один символ @';
-
-        const [, domain] = value.split('@');
-        if (!domain) return 'Укажите домен после @';
-        if (!domain.includes('.'))
-          return 'Домен должен содержать точку (например: example.com)';
-        if (domain.startsWith('.')) return 'Домен не может начинаться с точки';
-        if (domain.endsWith('.')) return 'Домен не может заканчиваться точкой';
-
-        if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)) {
-          return 'Некорректный формат email (пример: user@example.com)';
-        }
-
-        return isEmail('Некорректный формат email (пример: user@example.com)')(
-          value
-        );
-      },
-      password: (value) => {
-        const trimmed = value.trim();
-        if (trimmed !== value)
-          return 'Уберите пробелы в начале или конце пароля';
-        if (value.length < 8) return 'Пароль должен быть не менее 8 символов';
-        if (!/[A-Z]/.test(value))
-          return 'Добавьте хотя бы одну заглавную букву (A-Z)';
-        if (!/[a-z]/.test(value))
-          return 'Добавьте хотя бы одну строчную букву (a-z)';
-        if (!/[0-9]/.test(value)) return 'Добавьте хотя бы одну цифру (0-9)';
-        if (!/[!@#$%^&*]/.test(value))
-          return 'Добавьте хотя бы один спецсимвол (!@#$%^&*)';
-        return null;
-      },
+      email: (email) => validateEmail(email),
+      password: (password) => validatePassword(password),
     },
     validateInputOnChange: true,
   });
@@ -62,13 +29,14 @@ export const LoginForm = () => {
   };
 
   return (
-    <div className={classes.loginContainer}>
+    <Box className={classes.loginContainer}>
       <Card className={classes.loginCard}>
         <Title order={2} className={classes.loginTitle}>
           Вход в систему
         </Title>
 
-        <form
+        <Box
+          component="form"
           onSubmit={form.onSubmit(handleSubmit)}
           className={classes.loginForm}
           data-testid="login-form"
@@ -101,8 +69,8 @@ export const LoginForm = () => {
               Зарегистрироваться
             </Anchor>
           </Text>
-        </form>
+        </Box>
       </Card>
-    </div>
+    </Box>
   );
 };

--- a/src/pages/Registration/components/RegistrationForm/RegistrationForm.test.tsx
+++ b/src/pages/Registration/components/RegistrationForm/RegistrationForm.test.tsx
@@ -126,7 +126,7 @@ describe('component RegistrationForm', () => {
       await user.type(emailInput, 'user@example.com');
       await user.type(firstNameInput, 'Aleksandr');
       await user.type(lastNameInput, 'Yurkovskiy');
-      await user.type(passwordInput, '123456Sss');
+      await user.type(passwordInput, '123456Sss$');
       await user.type(dateOfBirth, '2001-05-05');
 
       await selectCountry(user);
@@ -180,49 +180,78 @@ describe('component RegistrationForm', () => {
 
 describe('validation component RegistrationForm', () => {
   describe('email', () => {
-    it('shows email validation error when is empty', async () => {
+    it('shows error for invalid email format', async () => {
       expect.hasAssertions();
 
       render(<RegistrationForm />);
-
-      const form = screen.getByTestId('registration-form');
-
-      fireEvent.submit(form);
-
-      await expect(
-        screen.findByText('Введите верный email (user@example.com)')
-      ).resolves.toBeInTheDocument();
-    });
-
-    it('shows error when email is invalid', async () => {
-      expect.hasAssertions();
-
-      render(<RegistrationForm />);
+      const user = userEvent.setup();
 
       const emailInput = screen.getByLabelText(/email/i);
 
-      const user = userEvent.setup();
-
-      await user.type(emailInput, 'w@rong@c.q');
+      await user.type(emailInput, 'invalid-email');
 
       await expect(
-        screen.findByText('Введите верный email (user@example.com)')
+        screen.findByText('Email должен содержать @')
+      ).resolves.toBeInTheDocument();
+
+      await user.clear(emailInput);
+      await user.type(emailInput, 'invalid-email@@');
+
+      await expect(
+        screen.findByText('Должен быть ровно один символ @')
       ).resolves.toBeInTheDocument();
     });
-  });
 
-  it('shows password validation error when is empty', async () => {
-    expect.hasAssertions();
+    it('shows error for email with leading/trailing spaces', async () => {
+      expect.hasAssertions();
 
-    render(<RegistrationForm />);
+      render(<RegistrationForm />);
+      const user = userEvent.setup();
 
-    const form = screen.getByTestId('registration-form');
+      const emailInput = screen.getByLabelText(/email/i);
 
-    fireEvent.submit(form);
+      await user.type(emailInput, '  user@example.com  ');
 
-    await expect(
-      screen.findByText('Пароль должен содержать 8 символов.')
-    ).resolves.toBeInTheDocument();
+      await expect(
+        screen.findByText('Уберите пробелы в начале или конце email')
+      ).resolves.toBeInTheDocument();
+    });
+
+    it('shows error for email without domain', async () => {
+      expect.hasAssertions();
+
+      render(<RegistrationForm />);
+      const user = userEvent.setup();
+
+      const emailInput = screen.getByLabelText(/email/i);
+      await user.type(emailInput, 'user@');
+
+      await expect(
+        screen.findByText('Укажите домен после @')
+      ).resolves.toBeInTheDocument();
+    });
+
+    it('shows error for email with invalid domain format', async () => {
+      expect.hasAssertions();
+
+      render(<RegistrationForm />);
+      const user = userEvent.setup();
+
+      const emailInput = screen.getByLabelText(/email/i);
+
+      await user.type(emailInput, 'user@example.');
+
+      await expect(
+        screen.findByText('Домен не может заканчиваться точкой')
+      ).resolves.toBeInTheDocument();
+
+      await user.clear(emailInput);
+      await user.type(emailInput, 'user@.example');
+
+      await expect(
+        screen.findByText('Домен не может начинаться с точки')
+      ).resolves.toBeInTheDocument();
+    });
   });
 
   it('shows firstName validation error when is empty', async () => {
@@ -235,7 +264,7 @@ describe('validation component RegistrationForm', () => {
     fireEvent.submit(form);
 
     await expect(
-      screen.findByText('Имя должно быть заполнено.')
+      screen.findByText('Имя должно быть заполнено')
     ).resolves.toBeInTheDocument();
   });
 
@@ -249,7 +278,7 @@ describe('validation component RegistrationForm', () => {
     fireEvent.submit(form);
 
     await expect(
-      screen.findByText('Фамилия должно быть заполнено.')
+      screen.findByText('Фамилия должна быть заполнена')
     ).resolves.toBeInTheDocument();
   });
 
@@ -264,7 +293,7 @@ describe('validation component RegistrationForm', () => {
       fireEvent.submit(form);
 
       await expect(
-        screen.findByText('Выберите дату.')
+        screen.findByText('Выберите дату')
       ).resolves.toBeInTheDocument();
     });
 
@@ -284,7 +313,7 @@ describe('validation component RegistrationForm', () => {
 
       await expect(
         screen.findByText(
-          'Чтобы пользоваться нашим сайтом, вы должны быть старше 13 лет.'
+          'Чтобы пользоваться нашим сайтом, вы должны быть старше 13 лет'
         )
       ).resolves.toBeInTheDocument();
     });
@@ -301,7 +330,7 @@ describe('validation component RegistrationForm', () => {
       fireEvent.submit(form);
 
       await expect(
-        screen.findByText('Выберите вашу страну.')
+        screen.findByText('Выберите вашу страну')
       ).resolves.toBeInTheDocument();
     });
 
@@ -318,7 +347,7 @@ describe('validation component RegistrationForm', () => {
       fireEvent.submit(form);
 
       await expect(
-        screen.findByText('Введите улицу.')
+        screen.findByText('Введите улицу')
       ).resolves.toBeInTheDocument();
     });
 
@@ -335,7 +364,7 @@ describe('validation component RegistrationForm', () => {
       fireEvent.submit(form);
 
       await expect(
-        screen.findByText('Введите название города.')
+        screen.findByText('Введите название города')
       ).resolves.toBeInTheDocument();
     });
 
@@ -360,71 +389,59 @@ describe('validation component RegistrationForm', () => {
   });
 
   describe('password', () => {
-    it('shows error when password length less than 8', async () => {
+    it('shows error for password with leading/trailing spaces', async () => {
       expect.hasAssertions();
 
       render(<RegistrationForm />);
-
-      const passwordInput = screen.getByLabelText(/пароль/i);
-
       const user = userEvent.setup();
 
-      await user.type(passwordInput, '1234');
+      const passwordInput = screen.getByLabelText(/пароль/i);
+      await user.type(passwordInput, ' validPass123! ');
 
       await expect(
-        screen.findByText('Пароль должен содержать 8 символов.')
+        screen.findByText('Уберите пробелы в начале или конце пароля')
       ).resolves.toBeInTheDocument();
     });
 
-    it('shows error when password not contains (A-Z)', async () => {
+    it('shows password requirements errors for weak password', async () => {
       expect.hasAssertions();
 
       render(<RegistrationForm />);
-
-      const passwordInput = screen.getByLabelText(/пароль/i);
-
       const user = userEvent.setup();
 
-      await user.type(passwordInput, '12345678');
+      const passwordInput = screen.getByLabelText(/пароль/i);
+      await user.type(passwordInput, 'simple');
 
       await expect(
-        screen.findByText(
-          'Пароль должен содержать хотя-бы 1 заглавную букву. (A-Z)'
-        )
+        screen.findByText('Пароль должен быть не менее 8 символов')
       ).resolves.toBeInTheDocument();
-    });
 
-    it('shows error when password not contains (a-z)', async () => {
-      expect.hasAssertions();
-
-      render(<RegistrationForm />);
-
-      const passwordInput = screen.getByLabelText(/пароль/i);
-
-      const user = userEvent.setup();
-
-      await user.type(passwordInput, '12345678A');
+      await user.clear(passwordInput);
+      await user.type(passwordInput, 'simplepa');
 
       await expect(
-        screen.findByText(
-          'Пароль должен содержать хотя-бы 1 строчную букву. (a-z)'
-        )
+        screen.findByText('Добавьте хотя бы одну заглавную букву (A-Z)')
       ).resolves.toBeInTheDocument();
-    });
 
-    it('shows error when password not contains (0-9)', async () => {
-      expect.hasAssertions();
-
-      render(<RegistrationForm />);
-
-      const passwordInput = screen.getByLabelText(/пароль/i);
-
-      const user = userEvent.setup();
-
-      await user.type(passwordInput, 'AAAAAAAa');
+      await user.clear(passwordInput);
+      await user.type(passwordInput, 'SIMPLEPASS');
 
       await expect(
-        screen.findByText('Пароль должен содержать хотя-бы 1 цифру')
+        screen.findByText('Добавьте хотя бы одну строчную букву (a-z)')
+      ).resolves.toBeInTheDocument();
+
+      await user.clear(passwordInput);
+      await user.type(passwordInput, 'simplePass');
+
+      await expect(
+        screen.findByText('Добавьте хотя бы одну цифру (0-9)')
+      ).resolves.toBeInTheDocument();
+
+      await user.clear(passwordInput);
+      await user.type(passwordInput, 'simplePass1');
+
+      await expect(
+        screen.findByText('Добавьте хотя бы один спецсимвол (!@#$%^&*)')
       ).resolves.toBeInTheDocument();
     });
   });

--- a/src/pages/Registration/components/RegistrationForm/RegistrationForm.tsx
+++ b/src/pages/Registration/components/RegistrationForm/RegistrationForm.tsx
@@ -14,15 +14,16 @@ import {
   Text,
 } from '@mantine/core';
 import { DatePickerInput } from '@mantine/dates';
-import { useForm, isEmail, isNotEmpty, hasLength } from '@mantine/form';
+import { useForm, isNotEmpty } from '@mantine/form';
 import { IconAt, IconCalendar, IconLock } from '@tabler/icons-react';
 import { COUNTRIES } from '@/constants/countries';
 import {
   combineRules,
-  isCorrectPostalCode,
   isDateDiffLessThan,
   isOnlyLetters,
-  notMatches,
+  validateEmail,
+  validatePassword,
+  validatePostalCode,
 } from '@/utils/mantine-validation';
 import AuthService from '@/services/AuthService';
 import { Link } from 'react-router';
@@ -58,49 +59,32 @@ const RegistrationForm = () => {
         },
       },
       validate: {
-        email: combineRules([
-          isNotEmpty('Введите верный email (user@example.com)'),
-          isEmail('Введите верный email (user@example.com)'),
-        ]),
-        password: combineRules([
-          hasLength({ min: 8 }, 'Пароль должен содержать 8 символов.'),
-          notMatches(
-            /[A-Z]/,
-            'Пароль должен содержать хотя-бы 1 заглавную букву. (A-Z)'
-          ),
-          notMatches(
-            /[a-z]/,
-            'Пароль должен содержать хотя-бы 1 строчную букву. (a-z)'
-          ),
-          notMatches(/[0-9]/, 'Пароль должен содержать хотя-бы 1 цифру'),
-        ]),
+        email: (email) => validateEmail(email),
+        password: (password) => validatePassword(password),
         firstName: combineRules([
-          isNotEmpty('Имя должно быть заполнено.'),
-          isOnlyLetters('Разрешены только буквы.'),
+          isNotEmpty('Имя должно быть заполнено'),
+          isOnlyLetters('Разрешены только буквы'),
         ]),
         lastName: combineRules([
-          isNotEmpty('Фамилия должно быть заполнено.'),
-          isOnlyLetters('Разрешены только буквы.'),
+          isNotEmpty('Фамилия должна быть заполнена'),
+          isOnlyLetters('Разрешены только буквы'),
         ]),
         dateOfBirth: combineRules([
-          isNotEmpty('Выберите дату.'),
+          isNotEmpty('Выберите дату'),
           isDateDiffLessThan(
             { target: 13, unit: 'years' },
-            'Чтобы пользоваться нашим сайтом, вы должны быть старше 13 лет.'
+            'Чтобы пользоваться нашим сайтом, вы должны быть старше 13 лет'
           ),
         ]),
         address: {
-          street: isNotEmpty('Введите улицу.'),
+          street: isNotEmpty('Введите улицу'),
           city: combineRules([
-            isNotEmpty('Введите название города.'),
-            isOnlyLetters('Город должен содержать только буквы.'),
+            isNotEmpty('Введите название города'),
+            isOnlyLetters('Город должен содержать только буквы'),
           ]),
-          postalCode: (value, values) =>
-            isCorrectPostalCode(
-              (countryName, format) =>
-                `Неверный адрес. ${countryName} имеет следующий формат ${format}`
-            )(value, values.address.country),
-          country: isNotEmpty('Выберите вашу страну.'),
+          postalCode: (postalCode, { address }) =>
+            validatePostalCode(postalCode, address.country),
+          country: isNotEmpty('Выберите вашу страну'),
         },
       },
       validateInputOnChange: true,
@@ -158,7 +142,6 @@ const RegistrationForm = () => {
           <TextInput
             label="Email"
             placeholder="user@example.com"
-            type="email"
             withAsterisk
             leftSection={<IconAt />}
             {...getInputProps('email')}

--- a/src/utils/mantine-validation.test.ts
+++ b/src/utils/mantine-validation.test.ts
@@ -5,6 +5,8 @@ import {
   isDateDiffLessThan,
   isOnlyLetters,
   notMatches,
+  validateEmail,
+  validatePassword,
 } from './mantine-validation';
 import { COUNTRIES } from '@/constants/countries';
 import { isNotEmpty } from '@mantine/form';
@@ -134,5 +136,135 @@ describe('isCorrectPostalCode validation mantine fn', () => {
     const result = isCorrectPostalCode(() => message)('123123', country.code);
 
     expect(result).toStrictEqual(message);
+  });
+});
+
+describe('validateEmail function', () => {
+  it('should return nothing for valid email', () => {
+    expect.hasAssertions();
+
+    const result = validateEmail('example@user.com');
+
+    expect(result).toBeNull();
+  });
+
+  it('shows error for invalid email format', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Должен быть ровно один символ @';
+
+    const result = validateEmail('invalid-email@@');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('shows error for email with leading/trailing spaces', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Уберите пробелы в начале или конце email';
+
+    const result = validateEmail(' user@example.com ');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('shows error for email without domain', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Укажите домен после @';
+
+    const result = validateEmail('user@');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('shows error for email when domain starts with dot(.)', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Домен не может начинаться с точки';
+
+    const result = validateEmail('user@.example');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('shows error for email when domain ends with dot(.)', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Домен не может заканчиваться точкой';
+
+    const result = validateEmail('user@example.');
+
+    expect(result).toBe(errorMessage);
+  });
+});
+
+describe('validatePassword function', () => {
+  it('should return nothing for valid email password', () => {
+    expect.hasAssertions();
+
+    const result = validatePassword('12345678Az$');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return error for password with leading/trailing spaces', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Уберите пробелы в начале или конце пароля';
+
+    const result = validatePassword(' validPass123! ');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('should return error for password with length less than 8', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Пароль должен быть не менее 8 символов';
+
+    const result = validatePassword('12345');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('should return error for password without symbol [A-Z]', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Добавьте хотя бы одну заглавную букву (A-Z)';
+
+    const result = validatePassword('12345678');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('should return error for password without symbol [a-z]', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Добавьте хотя бы одну строчную букву (a-z)';
+
+    const result = validatePassword('12345678A');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('should return error for password without symbol [0-9]', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Добавьте хотя бы одну цифру (0-9)';
+
+    const result = validatePassword('AAAAAAAAz');
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('should return error for password without symbol [!@#$%^&*]', () => {
+    expect.hasAssertions();
+
+    const errorMessage = 'Добавьте хотя бы один спецсимвол (!@#$%^&*)';
+
+    const result = validatePassword('12345678Az');
+
+    expect(result).toBe(errorMessage);
   });
 });

--- a/src/utils/mantine-validation.test.ts
+++ b/src/utils/mantine-validation.test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from 'vitest';
 import {
   combineRules,
-  isCorrectPostalCode,
+  validatePostalCode,
   isDateDiffLessThan,
   isOnlyLetters,
   notMatches,
@@ -10,6 +10,7 @@ import {
 } from './mantine-validation';
 import { COUNTRIES } from '@/constants/countries';
 import { isNotEmpty } from '@mantine/form';
+import { POSTAL_CODES } from '@/constants/postal-codes';
 
 describe('combineRules mantine fn', () => {
   it('should return undefined when validation passed', () => {
@@ -118,10 +119,7 @@ describe('isCorrectPostalCode validation mantine fn', () => {
 
     const [country] = COUNTRIES;
 
-    const result = isCorrectPostalCode(() => 'error message')(
-      '123 123',
-      country.code
-    );
+    const result = validatePostalCode('123 123', country.code);
 
     expect(result).toBeUndefined();
   });
@@ -130,10 +128,13 @@ describe('isCorrectPostalCode validation mantine fn', () => {
     expect.hasAssertions();
 
     const [country] = COUNTRIES;
+    const targetPostalCode = POSTAL_CODES.find(
+      (postalCode) => postalCode.iso === country.code
+    );
 
-    const message = `Wrong format for ${country.code}`;
+    const message = `Неверный адрес. ${targetPostalCode!.countryName} имеет следующий формат ${targetPostalCode!.format}`;
 
-    const result = isCorrectPostalCode(() => message)('123123', country.code);
+    const result = validatePostalCode('123123', country.code);
 
     expect(result).toStrictEqual(message);
   });

--- a/src/utils/mantine-validation.ts
+++ b/src/utils/mantine-validation.ts
@@ -47,21 +47,20 @@ export const isDateDiffLessThan =
     if (diff < target) return error;
   };
 
-export const isCorrectPostalCode =
-  (error: (countryName: string, format: string) => React.ReactNode) =>
-  (value: unknown, currentCountryCode?: string) => {
-    if (typeof value !== 'string') return;
+export const validatePostalCode = (
+  value: string,
+  currentCountryCode?: string
+) => {
+  const targetPostalCode = POSTAL_CODES.find(
+    (postalCode) => postalCode.iso === currentCountryCode
+  );
 
-    const targetPostalCode = POSTAL_CODES.find(
-      (postalCode) => postalCode.iso === currentCountryCode
-    );
+  if (!targetPostalCode) return true; // Если нет почтового кода, разрешаем любой
 
-    if (!targetPostalCode) return true; // Если нет почтового кода, разрешаем любой
-
-    if (!targetPostalCode.regex.test(value)) {
-      return error(targetPostalCode.countryName, targetPostalCode.format);
-    }
-  };
+  if (!targetPostalCode.regex.test(value)) {
+    return `Неверный адрес. ${targetPostalCode.countryName} имеет следующий формат ${targetPostalCode.format}`;
+  }
+};
 
 export const validateEmail = (value: string) => {
   const trimmed = value.trim();

--- a/src/utils/mantine-validation.ts
+++ b/src/utils/mantine-validation.ts
@@ -1,6 +1,6 @@
 import { POSTAL_CODES } from '@/constants/postal-codes';
 import dayjs, { OpUnitType, QUnitType } from 'dayjs';
-import React from 'react';
+import { isEmail as mantineIsEmail } from '@mantine/form';
 
 type ValidationFunction = (value: unknown) => React.ReactNode;
 
@@ -62,3 +62,40 @@ export const isCorrectPostalCode =
       return error(targetPostalCode.countryName, targetPostalCode.format);
     }
   };
+
+export const validateEmail = (value: string) => {
+  const trimmed = value.trim();
+
+  if (trimmed !== value) return 'Уберите пробелы в начале или конце email';
+  if (!value.includes('@')) return 'Email должен содержать @';
+  if (value.split('@').length !== 2) return 'Должен быть ровно один символ @';
+
+  const [, domain] = value.split('@');
+  if (!domain) return 'Укажите домен после @';
+  if (!domain.includes('.'))
+    return 'Домен должен содержать точку (например: example.com)';
+  if (domain.startsWith('.')) return 'Домен не может начинаться с точки';
+  if (domain.endsWith('.')) return 'Домен не может заканчиваться точкой';
+
+  if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)) {
+    return 'Некорректный формат email (пример: user@example.com)';
+  }
+
+  return mantineIsEmail('Некорректный формат email (пример: user@example.com)')(
+    value
+  );
+};
+
+export const validatePassword = (value: string) => {
+  const trimmed = value.trim();
+
+  if (trimmed !== value) return 'Уберите пробелы в начале или конце пароля';
+  if (value.length < 8) return 'Пароль должен быть не менее 8 символов';
+  if (!/[A-Z]/.test(value))
+    return 'Добавьте хотя бы одну заглавную букву (A-Z)';
+  if (!/[a-z]/.test(value)) return 'Добавьте хотя бы одну строчную букву (a-z)';
+  if (!/[0-9]/.test(value)) return 'Добавьте хотя бы одну цифру (0-9)';
+  if (!/[!@#$%^&*]/.test(value))
+    return 'Добавьте хотя бы один спецсимвол (!@#$%^&*)';
+  return null;
+};


### PR DESCRIPTION
1. ##### 🔗 **_Related Task_**: [YouTrack](https://ecommerce-application.youtrack.cloud/issue/EA-23/Make-form-validation-common-with-the-same-errors-and-cases)
2. ##### 📸 **_Screenshot_**: 
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/12ca0815-2c0a-4fc8-9d7a-4e01f8c1ffa0" />

3. ##### 🏁 **_Sprint_**: sprint2
4. ##### ✨ **_Summary_**: Moved email and password validation to separate functions, wrote tests for them. Used new functions for email password validation. Now the same validation errors are used.
Also, instead of the usual elements, I added a Mantin Box component with the required component to the login page

5. ##### 🌐 **_Deployment_**: 
5.1) Registration - https://6822468d6e234d8b23394ec5--jolly-florentine-654ee6.netlify.app/registration
5.2) Login  https://6822468d6e234d8b23394ec5--jolly-florentine-654ee6.netlify.app/login
